### PR TITLE
Stack resource listing

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -5,6 +5,7 @@ use aws_sdk_cloudformation as cloudformation;
 use aws_sdk_cloudformation::types::{StackResource, StackSummary};
 use aws_sdk_dynamodb as dynamodb;
 use std::error::Error;
+use std::sync::Arc;
 
 /// Get the AWS config to grab stack details from default default_provider
 // TODO: We need to give the user the ability to run this and pass in a specific profile similar to
@@ -41,7 +42,7 @@ pub async fn get_stacks() -> Result<Vec<StackSummary>, cloudformation::Error> {
 }
 
 pub async fn get_stack_resources(
-    stack: &StackSummary,
+    stack: Arc<StackSummary>,
 ) -> Result<Vec<StackResource>, cloudformation::Error> {
     let config = create_config().await.unwrap();
     let client = cloudformation::Client::new(&config);

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -2,7 +2,7 @@ use aws_config::BehaviorVersion;
 use aws_config::SdkConfig;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_cloudformation as cloudformation;
-use aws_sdk_cloudformation::types::StackSummary;
+use aws_sdk_cloudformation::types::{StackResource, StackSummary};
 use aws_sdk_dynamodb as dynamodb;
 use std::error::Error;
 
@@ -38,4 +38,20 @@ pub async fn get_stacks() -> Result<Vec<StackSummary>, cloudformation::Error> {
 
     let stacks = resp.stack_summaries.unwrap();
     Ok(stacks)
+}
+
+pub async fn get_stack_resources(
+    stack: &StackSummary,
+) -> Result<Vec<StackResource>, cloudformation::Error> {
+    let config = create_config().await.unwrap();
+    let client = cloudformation::Client::new(&config);
+
+    let resp = client
+        .describe_stack_resources()
+        .stack_name(stack.stack_name().unwrap())
+        .send()
+        .await
+        .unwrap();
+    let stack_resources = resp.stack_resources.unwrap();
+    Ok(stack_resources)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,16 @@
 mod aws;
+mod views;
+use views::stack_view::Stack;
 
 use aws_sdk_cloudformation::types::StackSummary;
 use color_eyre::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use open;
 use ratatui::{
     DefaultTerminal, Frame,
     layout::{Constraint, Direction, Layout},
     style::{Style, Stylize},
     text::Line,
-    widgets::{Block, List, ListState},
+    widgets::{Block, List, ListState, Widget},
 };
 use tokio::spawn;
 
@@ -19,17 +20,12 @@ async fn main() -> color_eyre::Result<()> {
     let stacks = stack_handle.await.unwrap().unwrap();
 
     color_eyre::install()?;
+
+    // TODO: Tokio and UI running on the same thread. Every call to AWS is blocking! FIX!
     let terminal = ratatui::init();
     let result = App::new(&stacks).run(terminal);
     ratatui::restore();
     result
-}
-
-/// The main application which holds the state and logic of the application.
-#[derive(Debug)]
-pub struct App<'a> {
-    running: bool,
-    stack_list: StackList<'a>,
 }
 
 /// List of cloudformation stacks in the users default environment
@@ -39,15 +35,33 @@ struct StackList<'a> {
     state: ListState,
 }
 
+/// The main application which holds the state and logic of the application.
+#[derive(Debug)]
+pub struct App<'a> {
+    running: bool,
+    view: View,
+    stack_list: StackList<'a>,
+    current_stack: Option<&'a StackSummary>,
+}
+
+#[derive(Debug, Default, PartialEq)]
+enum View {
+    #[default]
+    Stacks,
+    Resources,
+}
+
 impl<'a> App<'a> {
     /// Construct a new instance of [`App`].
     pub fn new(stacks: &'a Vec<StackSummary>) -> Self {
         Self {
             running: false,
+            view: View::Stacks,
             stack_list: StackList {
                 stacks: stacks,
                 state: ListState::default(),
             },
+            current_stack: None,
         }
     }
 
@@ -74,14 +88,20 @@ impl<'a> App<'a> {
             .split(frame.area());
 
         let title = Line::from("Owl").bold().blue().centered();
-        let text = "An integration stack visualiser and configuration UI. \n\n\
-            Press `Esc`, `Ctrl-C` or `q` to stop running.";
+        let text = "An integration stack visualiser and configuration UI. \n\n
+            Press `Esc`, `Ctrl-C` or `q` to stop running. Press `Backspace` to navigate back.";
 
         let title_block = Block::new().title(title);
         let tagline = Line::from(text).centered();
 
         frame.render_widget(&title_block, layout[0]);
         frame.render_widget(tagline, title_block.inner(layout[0]));
+
+        if self.view == View::Resources {
+            let stack_view = Stack::new(self.current_stack.unwrap()).await?;
+            stack_view.render(layout[1], frame.buffer_mut());
+            return;
+        }
 
         // Stack Menu
         frame.render_stateful_widget(
@@ -120,25 +140,26 @@ impl<'a> App<'a> {
             // Add other key handlers here.
             (_, KeyCode::Down) => self.stack_list.state.select_next(),
             (_, KeyCode::Up) => self.stack_list.state.select_previous(),
-            (_, KeyCode::Enter) => self.go_to_stack_link(),
+            (_, KeyCode::Enter) => self.select_stack(),
+            (_, KeyCode::Backspace) => self.back(),
             _ => {}
         }
     }
 
-    /// Open a link to the selected stack in AWS Console
-    fn go_to_stack_link(&mut self) {
+    fn select_stack(&mut self) {
         let index = self
             .stack_list
             .state
             .selected()
             .expect("Unable to find a selected index");
 
-        let stack_arn = self.stack_list.stacks[index].stack_id().unwrap();
+        self.current_stack = Some(&self.stack_list.stacks[index]);
+        self.view = View::Resources;
+    }
 
-        let _ = open::that(format!(
-            "https://console.aws.amazon.com/go/view?arn={}",
-            stack_arn
-        ));
+    fn back(&mut self) {
+        self.current_stack = None;
+        self.view = View::Stacks;
     }
 
     /// Set running to false to quit the application.

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,0 +1,1 @@
+pub mod stack_view;

--- a/src/views/stack_view.rs
+++ b/src/views/stack_view.rs
@@ -3,28 +3,48 @@ use aws_sdk_cloudformation::types::{StackResource, StackSummary};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    widgets::{Block, Clear, Widget},
+    widgets::{Block, Clear, List, Widget},
 };
+use std::sync::Arc;
+use tokio::runtime::Builder;
 
-pub struct Stack<'a> {
-    stack_summary: &'a StackSummary,
+pub struct Stack {
+    stack_summary: Arc<StackSummary>,
     resources: Vec<StackResource>,
 }
 
-impl<'a> Stack<'a> {
-    pub async fn new(stack_summary: &'a StackSummary) -> Self {
+impl Stack {
+    pub fn new(stack_summary: Arc<StackSummary>) -> Self {
+        let runtime = Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let handle = runtime.spawn(get_stack_resources(stack_summary.clone()));
+        // TODO: This is still blocking the main UI thread from rendering. Need to figure out a way
+        // to render an empty list, and then re-render one the runtime has grabbed what it needs
+        // from AWS
+        let resources = runtime.block_on(handle).unwrap().unwrap();
         Self {
             stack_summary,
-            resources: get_stack_resources(stack_summary).await.unwrap(),
+            resources,
         }
     }
 }
 
-impl<'a> Widget for &Stack<'a> {
+impl Widget for &Stack {
     fn render(self, area: Rect, buf: &mut Buffer) {
         Clear.render(area, buf);
         Widget::render(
-            Block::bordered().title(self.stack_summary.stack_name().unwrap()),
+            List::new::<Vec<&str>>(
+                self.resources
+                    .clone()
+                    .iter()
+                    .map(|resource| resource.logical_resource_id().unwrap())
+                    .collect(),
+            )
+            .block(Block::bordered().title(self.stack_summary.stack_name().unwrap())),
             area,
             buf,
         );

--- a/src/views/stack_view.rs
+++ b/src/views/stack_view.rs
@@ -1,16 +1,24 @@
 use crate::aws::get_stack_resources;
 use aws_sdk_cloudformation::types::{StackResource, StackSummary};
+
 use ratatui::{
     buffer::Buffer,
-    layout::Rect,
+    layout::{Constraint, Direction, Layout, Rect},
     widgets::{Block, Clear, List, Widget},
 };
 use std::sync::Arc;
 use tokio::runtime::Builder;
 
 pub struct Stack {
-    stack_summary: Arc<StackSummary>,
-    resources: Vec<StackResource>,
+    _stack_summary: Arc<StackSummary>,
+    resources: Resources,
+}
+
+#[derive(Debug, Clone)]
+struct Resources {
+    lambdas: Vec<StackResource>,
+    state_machines: Vec<StackResource>,
+    apis: Vec<StackResource>,
 }
 
 impl Stack {
@@ -25,28 +33,83 @@ impl Stack {
         // TODO: This is still blocking the main UI thread from rendering. Need to figure out a way
         // to render an empty list, and then re-render one the runtime has grabbed what it needs
         // from AWS
+        // It would actually be WAY better if cached this!
         let resources = runtime.block_on(handle).unwrap().unwrap();
+
         Self {
-            stack_summary,
-            resources,
+            _stack_summary: stack_summary,
+            resources: Self::sort(resources),
         }
     }
-}
 
-impl Widget for &Stack {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        Clear.render(area, buf);
+    fn sort(resources: Vec<StackResource>) -> Resources {
+        let mut sorted = Resources {
+            lambdas: vec![],
+            state_machines: vec![],
+            apis: vec![],
+        };
+
+        resources.iter().for_each(|resource| -> () {
+            match resource.resource_type() {
+                Some("AWS::Lambda::Function") => sorted.lambdas.push(resource.clone()),
+                Some("AWS::StepFunctions::StateMachine") => {
+                    sorted.state_machines.push(resource.clone())
+                }
+                Some("AWS::ApiGatewayRestApi") => sorted.apis.push(resource.clone()),
+                Some(_x) => (),
+                None => (),
+            }
+        });
+
+        return sorted;
+    }
+
+    fn render_list(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        resources: &Vec<StackResource>,
+        title: &str,
+    ) -> () {
         Widget::render(
             List::new::<Vec<&str>>(
-                self.resources
+                resources
                     .clone()
                     .iter()
                     .map(|resource| resource.logical_resource_id().unwrap())
                     .collect(),
             )
-            .block(Block::bordered().title(self.stack_summary.stack_name().unwrap())),
+            .block(Block::bordered().title(title)),
             area,
             buf,
         );
+    }
+}
+
+impl Widget for &Stack {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+            ])
+            .split(area);
+        Clear.render(area, buf);
+
+        self.render_list(layout[0], buf, &self.resources.lambdas, "Lambda Functions");
+        self.render_list(
+            layout[1],
+            buf,
+            &self.resources.state_machines,
+            "State Machines",
+        );
+        self.render_list(
+            layout[2],
+            buf,
+            &self.resources.apis,
+            "API Gateway Rest APIs",
+        )
     }
 }

--- a/src/views/stack_view.rs
+++ b/src/views/stack_view.rs
@@ -1,0 +1,32 @@
+use crate::aws::get_stack_resources;
+use aws_sdk_cloudformation::types::{StackResource, StackSummary};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    widgets::{Block, Clear, Widget},
+};
+
+pub struct Stack<'a> {
+    stack_summary: &'a StackSummary,
+    resources: Vec<StackResource>,
+}
+
+impl<'a> Stack<'a> {
+    pub async fn new(stack_summary: &'a StackSummary) -> Self {
+        Self {
+            stack_summary,
+            resources: get_stack_resources(stack_summary).await.unwrap(),
+        }
+    }
+}
+
+impl<'a> Widget for &Stack<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        Clear.render(area, buf);
+        Widget::render(
+            Block::bordered().title(self.stack_summary.stack_name().unwrap()),
+            area,
+            buf,
+        );
+    }
+}


### PR DESCRIPTION
This PR adds the ability to view a specific stack resources by category. 

Each list lists out logical ids, with the plan in future for these lists to be stateful and intractable. 

**Note:**
Error handling is pretty raw right now. We are mostly just unwrapping our Options rather than actually checking them. Ideally we would unwrap with default, or case match them for better errors. 

The plan in future is to prevent panics and instead render a UI element if any errors occur during resource fetching, Ratatui has an inbuilt UI Panic which I havent explored yet. 